### PR TITLE
New features (disable author pages & prevent installation of new default WordPress themes)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,11 +26,8 @@ $ git clone https://github.com/webarthur/advanced-settings.git
 
 ## New Features
 
-* New admin page: Scripts
-* Remove *type="text/javascript"* attribute from &lt;script&gt; tag
-* Track and list enqueued scripts
-* Merge and include removed scripts
-* Load merged removed scripts in footer
+* Disable author pages
+* Prevent installation of new default WordPress themes during core updates
 
 ## What can this do?
 
@@ -73,6 +70,8 @@ $ git clone https://github.com/webarthur/advanced-settings.git
 - Track and list enqueued scripts
 - Merge and include removed scripts
 - Load merged removed scripts in footer
+- Disable author pages
+- Prevent installation of new default WordPress themes during core updates
 and more to come ...
 
 Visit: https://devarthur.com/

--- a/admin-system.php
+++ b/admin-system.php
@@ -70,6 +70,13 @@
 							<?php _e('Disable Posts Auto Saving') ?>
 						</label>
 
+						<br />
+
+						<label for="disable_author_pages">
+							<input name="disable_author_pages" type="checkbox" id="disable_author_pages" value="1" <?php advset_check_if('disable_author_pages') ?> />
+							<?php _e('Disable Author Pages') ?>
+						</label>
+
 					</fieldset>
 				</td>
 			</tr>

--- a/admin-system.php
+++ b/admin-system.php
@@ -133,6 +133,8 @@
 			<tr valign="top">
 				<th scope="row"><?php _e('System'); ?></th>
 				<td>
+					<fieldset>
+
 					<?php /*if( !defined('EMPTY_TRASH_DAYS') ) { ?>
 					<label for="empty_trash">
 						<?php _e('Posts stay in the trash for ') ?>
@@ -142,6 +144,13 @@
 
 					<br />
 					<? } else echo EMPTY_TRASH_DAYS;*/ ?>
+
+					<label for="core_upgrade_skip_new_bundled">
+						<input name="core_upgrade_skip_new_bundled" type="checkbox" id="core_upgrade_skip_new_bundled" value="1" <?php advset_check_if('core_upgrade_skip_new_bundled') ?> />
+						<?php _e('Prevent installation of new default WordPress themes during core updates') ?>
+					</label>
+
+					<br />
 
 					<label for="show_query_num">
 						<input name="show_query_num" type="checkbox" id="show_query_num" value="1" <?php advset_check_if('show_query_num') ?> />
@@ -154,6 +163,7 @@
 						<?php // _e('Fix post type pagination') ?>
 					</label-->
 
+					</fieldset>
 				</td>
 			</tr>
 

--- a/index.php
+++ b/index.php
@@ -359,6 +359,25 @@ if( advset_option('remove_comments_system') ) {
 	add_action( 'wp_before_admin_bar_render', '__av_admin_bar_render' );
 }
 
+# Disable author pages
+if ( advset_option('disable_author_pages') ) {
+    function advset_disable_author_pages__template_redirect() {
+        global $wp_query;
+        if ( is_author() ) {
+            $wp_query->set_404();
+            status_header(404);
+        }
+    }
+    add_action( 'template_redirect', 'advset_disable_author_pages__template_redirect' );
+    function advset_disable_author_pages__wp_sitemaps_add_provider( $provider, $name ) {
+        if ( 'users' === $name ) {
+            return false;
+        }
+        return $provider;
+    }
+    add_filter( 'wp_sitemaps_add_provider', 'advset_disable_author_pages__wp_sitemaps_add_provider', 10, 2 );
+}
+
 # Google Analytics
 if( advset_option('analytics') ) {
 	add_action('wp_footer', '____analytics'); // Load custom styles

--- a/index.php
+++ b/index.php
@@ -5,7 +5,7 @@ Plugin URI: https://wordpress.org/plugins/advanced-settings/
 Description: Advanced settings for WordPress.
 Author: Arthur Ronconi
 Author URI: https://devarthur.com/
-Version: 2.4.0
+Version: 2.5.0
 Requires at least: 5.0.0
 Requires PHP: 5.3
 */

--- a/index.php
+++ b/index.php
@@ -391,6 +391,13 @@ gtag('config', '$ga_code')";
 	}
 }
 
+# core upgrade skip new bundled
+if ( advset_option('core_upgrade_skip_new_bundled') ) {
+    if (!defined('CORE_UPGRADE_SKIP_NEW_BUNDLED')) {
+        define('CORE_UPGRADE_SKIP_NEW_BUNDLED', true);
+    }
+}
+
 # Remove admin menu
 if( advset_option('show_query_num') ) {
 	function __show_sql_query_num(){

--- a/readme.txt
+++ b/readme.txt
@@ -6,8 +6,8 @@ Author URI: https://devarthur.com/
 Plugin URI: https://wordpress.org/plugins/advanced-settings/
 Tags: settings, performance, speed, admin, post type, menu, page, image, setting, images, google, analytics, compress, html, thumbnail, auto save, seo, keywords, favicon, feedburner, compact, comments, remove comments, hide comments, author, resize at upload, auto post thumbnails, filters, widget, option
 Requires at least: 5.0.0
-Tested up to: 6.4.2
-Stable tag: 2.4.0
+Tested up to: 6.4.3
+Stable tag: 2.5.0
 License: GPLv3 or later
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 

--- a/readme.txt
+++ b/readme.txt
@@ -106,6 +106,10 @@ Upload plugin to your blog, activate it, then click on a setting options in admi
 
 == Changelog ==
 
+= 2.5.0 =
+* Add new feature: Disable author pages
+* Add new feature: Prevent installation of new default WordPress themes during core updates
+
 = 2.4.0 =
 * Updated code for WordPress version 6.4.2
 

--- a/readme.txt
+++ b/readme.txt
@@ -110,6 +110,9 @@ Upload plugin to your blog, activate it, then click on a setting options in admi
 
 == Changelog ==
 
+= 2.4.0 =
+* Updated code for WordPress version 6.4.2
+
 = 2.3.4 =
 * Updated code for WordPress version 5.5.3
 

--- a/readme.txt
+++ b/readme.txt
@@ -69,7 +69,6 @@ This is an essential plugin for your WordPress websites.
 * Set JPEG quality
 * Resize image at upload to max size
 * Display total number of executed SQL queries and page loading time
-* Fix post type pagination
 
 = Scripts =
 

--- a/readme.txt
+++ b/readme.txt
@@ -19,13 +19,8 @@ This is an essential plugin for your WordPress websites.
 
 = New Features =
 
-* New admin page: Scripts
-* New admin page: Styles
-* Remove *type="text/javascript"* attribute from &lt;script&gt; tag
-* Track and list enqueued scripts/styles
-* Merge and include removed scripts/styles
-* Load merged removed scripts in footer
-* Load merged removed styles
+* Disable author pages
+* Prevent installation of new default WordPress themes during core updates
 
 = Post types =
 
@@ -65,9 +60,11 @@ This is an essential plugin for your WordPress websites.
 * Disable widget system
 * Disable comment system
 * Disable Posts Auto Saving
+* Disable author pages
 * Automatically generate the Post Thumbnail (from the first image in post)
 * Set JPEG quality
 * Resize image at upload to max size
+* Prevent installation of new default WordPress themes during core updates
 * Display total number of executed SQL queries and page loading time
 
 = Scripts =


### PR DESCRIPTION
Hey Arthur!

I also sent you an email 🙂

This pull request includes the following new features. If you think they are useful, feel free to add them if you like.

1. **Disable author pages**
_This removes /author/... URLs from sitemap.xml and returns a 404 page for author page requests_

2. **Prevent installation of new default WordPress themes during core updates**
_This prevents themes like "Twenty Twenty-Four" from being automatically downloaded and installed during the WordPress core update._